### PR TITLE
Setting up Dev on CI + Python 3.8 support changes.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: Continuous Integration
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "dev" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "dev" ]
 
 permissions:
   contents: read
@@ -32,6 +32,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install flake8 pytest
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+        pip install -e .
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names

--- a/bytemaker/typing_redirect.py
+++ b/bytemaker/typing_redirect.py
@@ -2,37 +2,13 @@
 typing_redirect.py
 
 This module allows for Python version-agnostic typing and collections.abc imports.
-    It uses Python standard library batteries for verions >=3.9.
-    For versions <3.9, it uses the typing_extensions module.
+    It uses Python standard library batteries where possible.
+    For older versions, this module will export from typing_extensions.
 """
 import sys
 
 if sys.version_info < (3, 9):
-    from typing import ClassVar, Final, Protocol, Type, runtime_checkable
-
-    from typing_extensions import (
-        Annotated,
-        Any,
-        Callable,
-        Dict,
-        ForwardRef,
-        Iterable,
-        Iterator,
-        List,
-        Mapping,
-        MutableMapping,
-        MutableSequence,
-        Optional,
-        Self,
-        Sequence,
-        Tuple,
-        TypeVar,
-        Union,
-        get_args,
-        get_origin,
-        get_type_hints,
-        overload,
-    )
+    from typing import Callable, Iterable, Mapping, MutableMapping, Sequence
 else:
     from collections.abc import (
         Callable,
@@ -42,31 +18,29 @@ else:
         MutableSequence,
         Sequence,
     )
-    from typing import (
-        Annotated,
-        Any,
-        ClassVar,
-        Dict,
-        Final,
-        ForwardRef,
-        Iterator,
-        List,
-        Optional,
-        Protocol,
-        Self,
-        Tuple,
-        Type,
-        TypeVar,
-        Union,
-        get_args,
-        get_origin,
-        get_type_hints,
-        overload,
-        runtime_checkable,
-    )
+
+from typing import (
+    Any,
+    ClassVar,
+    Dict,
+    Final,
+    ForwardRef,
+    Iterator,
+    List,
+    Optional,
+    Protocol,
+    Tuple,
+    Type,
+    TypeVar,
+    Union,
+    get_args,
+    get_origin,
+    get_type_hints,
+    overload,
+    runtime_checkable,
+)
 
 __all__ = [
-    "Annotated",
     "Any",
     "Callable",
     "ClassVar",
@@ -81,7 +55,6 @@ __all__ = [
     "MutableSequence",
     "Optional",
     "Protocol",
-    "Self",
     "Sequence",
     "Tuple",
     "Type",
@@ -93,3 +66,8 @@ __all__ = [
     "overload",
     "runtime_checkable",
 ]
+
+if sys.version_info >= (3, 11):
+    from typing import Self  # noqa: F401
+
+    __all__.append("Self")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,8 +13,8 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent"]
 
-[project.dependencies]
-typing-extensions = ['typing-extensions >= 4.11; python_version < "3.9"']
+dependencies = [
+    "typing-extensions >= 4.11; python_version < '3.9'"]
 
 [project.urls]
 "Homepage" = "https://github.com/dem1995/bytemaker"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,8 +13,8 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent"]
 
-dependencies = [
-    "typing-extensions >= 4.11; python_version < '3.9'"]
+# dependencies = [
+#     "typing-extensions >= 4.11; python_version < '3.11'"]
 
 [project.urls]
 "Homepage" = "https://github.com/dem1995/bytemaker"


### PR DESCRIPTION
- Adding dev to CI
- removing Self from typing_extensions (thus unifying 3.8 and >3.8)
- prepping a future change to pyproject.toml when 3.11 becomes the minimum version