### PR TITLE
fix(conversions): resolve dataclass field annotations via get_type_hints

### DIFF
--- a/bytemaker/conversions/aggregate_types.py
+++ b/bytemaker/conversions/aggregate_types.py
@@ -18,7 +18,7 @@ from bytemaker.conversions.pytypes import (
     pytype_to_bits,
     pytype_to_bytes,
 )
-from bytemaker.typing_redirect import Iterable, Literal, Union
+from bytemaker.typing_redirect import Dict, Iterable, Literal, Union, get_type_hints
 from bytemaker.utils import DataClassType, is_instance_of_union, is_subclass_of_union
 
 UnitType = Union[CType, BitType, PyType]
@@ -26,6 +26,26 @@ UnitType = Union[CType, BitType, PyType]
 # CType is a Union of _SimpleCData, Structure, Union, and Array
 # YType is a Union of YInt, YFloat, YString, YBytes, YBool, YEnum, YArray, and YStruct
 # PyType is a Union of int, float, str, bytes, bool, and Enum
+
+
+def resolve_field_types(dataclass_type: type) -> Dict[str, type]:
+    """
+    Resolve a dataclass's field annotations to concrete types.
+
+    Field annotations are strings rather than types whenever the defining
+    module uses ``from __future__ import annotations`` (PEP 563) or otherwise
+    stringizes its annotations. ``typing.get_type_hints`` evaluates those
+    strings in the namespace of the module that defined the dataclass, so
+    concrete types such as ``SInt16`` resolve correctly. A bare ``eval`` would
+    instead resolve them in bytemaker's own namespace and raise ``NameError``.
+
+    For non-stringized annotations the field types are already real objects and
+    are returned unchanged, so this is safe to use unconditionally.
+
+    Returns:
+        Dict[str, type]: A mapping from field name to its resolved type.
+    """
+    return get_type_hints(dataclass_type)
 
 
 def count_bits_in_unit_type(unit_type: UnitType) -> int:
@@ -44,11 +64,9 @@ def count_bits_in_unit_type(unit_type: UnitType) -> int:
         return ConversionConfig.get_conversion_info(unit_type).num_bits("")
     elif is_subclass_of_union(unit_type, DataClassType):
         size_in_bits = 0
+        field_types = resolve_field_types(unit_type)
         for field in dataclasses.fields(unit_type):
-            field_type = field.type
-            if isinstance(field_type, str):
-                field_type = eval(field_type)
-            size_in_bits += count_bits_in_unit_type(field_type)
+            size_in_bits += count_bits_in_unit_type(field_types[field.name])
         return size_in_bits
 
 
@@ -62,11 +80,9 @@ def count_bits_in_aggregate_type(aggregate_type: type) -> int:
         return count_bits_in_unit_type(aggregate_type)
     else:
         size_in_bits = 0
+        field_types = resolve_field_types(aggregate_type)
         for field in dataclasses.fields(aggregate_type):
-            field_type = field.type
-            if isinstance(field_type, str):
-                field_type = eval(field_type)
-            size_in_bits += count_bits_in_unit_type(field_type)
+            size_in_bits += count_bits_in_unit_type(field_types[field.name])
         return size_in_bits
 
 
@@ -225,11 +241,9 @@ def to_bits_aggregate(convertible_object: AggregateTypeByteConvertible) -> BitVe
         ret_bits = to_bits_individual(convertible_object)
     elif isinstance(convertible_object, DataClassType):
         fields = dataclasses.fields(convertible_object)
+        resolved_types = resolve_field_types(type(convertible_object))
         field_values = [getattr(convertible_object, field.name) for field in fields]
-        field_types = [
-            field.type if not isinstance(field.type, str) else eval(field.type)
-            for field in fields
-        ]
+        field_types = [resolved_types[field.name] for field in fields]
         # print("types", field_types)
         # print("type_is_dataclass", [isinstance(field_type, DataClassType)
         # for field_type in field_types])
@@ -292,10 +306,9 @@ def from_bits_aggregate(
             )
 
         read_fields = list()
+        field_types = resolve_field_types(aggregate_type)
         for field in dataclasses.fields(aggregate_type):
-            field_type = field.type
-            if isinstance(field.type, str):
-                field_type = eval(field.type)
+            field_type = field_types[field.name]
 
             field_size_in_bits = count_bits_in_unit_type(field_type)
             field_bits = unitbits[:field_size_in_bits]
@@ -330,10 +343,9 @@ def to_bytes_aggregate(
         ret_bytes = to_bytes_individual(units, endianness=endianness)
 
     elif isinstance(units, DataClassType):
+        field_types = resolve_field_types(type(units))
         for field in dataclasses.fields(units):
-            field_type = field.type
-            if isinstance(field.type, str):
-                field_type = eval(field_type)
+            field_type = field_types[field.name]
             field_value = getattr(units, field.name)
             field_value = trycast(field_value, field_type)
             field_value_bytes = to_bytes_aggregate(field_value, endianness=endianness)
@@ -386,10 +398,9 @@ def from_bytes_aggregate(
                 )
 
             read_fields = list()
+            field_types = resolve_field_types(aggregate_type)
             for field in dataclasses.fields(aggregate_type):
-                field_type = field.type
-                if isinstance(field.type, str):
-                    field_type = eval(field.type)
+                field_type = field_types[field.name]
                 field_size_in_bytes = (count_bits_in_unit_type(field_type) + 7) // 8
                 field_bytes = bytes_obj[:field_size_in_bytes]
                 field_value = from_bytes_aggregate(

--- a/test/future_annotations_test.py
+++ b/test/future_annotations_test.py
@@ -1,0 +1,72 @@
+"""Regression tests for PEP 563 stringized annotations.
+
+This module imports ``from __future__ import annotations`` at the top, which
+turns every dataclass field annotation below into a string (e.g. "SInt16")
+instead of the type object. Aggregate (de)serialization must resolve those
+strings in the *defining module's* namespace via typing.get_type_hints. A
+previous implementation used a bare ``eval`` that resolved them in bytemaker's
+own namespace, raising ``NameError: name 'SInt16' is not defined`` for any
+caller that used this future import.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from bytemaker.bittypes import SInt16, UInt8, UInt16
+from bytemaker.conversions.aggregate_types import (
+    count_bits_in_aggregate_type,
+    from_bits_aggregate,
+    from_bytes_aggregate,
+    to_bits_aggregate,
+    to_bytes_aggregate,
+)
+
+
+@dataclass
+class Vitals:
+    hp: SInt16  # signed, so 0xFFFF -> -1
+    max_hp: UInt16
+
+
+@dataclass
+class WithNested:
+    tag: UInt8
+    vitals: Vitals
+
+
+def test_count_bits_with_stringized_annotations():
+    assert count_bits_in_aggregate_type(Vitals) == 32
+    assert count_bits_in_aggregate_type(WithNested) == 8 + 32
+
+
+def test_to_from_bytes_with_stringized_annotations():
+    raw = to_bytes_aggregate(Vitals(SInt16(-1), UInt16(100)))
+    assert raw == b"\xff\xff\x00\x64"
+    result = from_bytes_aggregate(raw, Vitals)
+    assert result.hp.value == -1
+    assert result.max_hp.value == 100
+
+
+def test_to_from_bits_with_stringized_annotations():
+    original = Vitals(SInt16(-50), UInt16(999))
+    bits = to_bits_aggregate(original)
+    result = from_bits_aggregate(bits, Vitals)
+    assert result.hp.value == -50
+    assert result.max_hp.value == 999
+
+
+def test_nested_dataclass_with_stringized_annotations():
+    original = WithNested(UInt8(7), Vitals(SInt16(-1), UInt16(100)))
+
+    bits = to_bits_aggregate(original)
+    from_bits = from_bits_aggregate(bits, WithNested)
+    assert from_bits.tag.value == 7
+    assert from_bits.vitals.hp.value == -1
+    assert from_bits.vitals.max_hp.value == 100
+
+    raw = to_bytes_aggregate(original)
+    from_bytes = from_bytes_aggregate(raw, WithNested)
+    assert from_bytes.tag.value == 7
+    assert from_bytes.vitals.hp.value == -1
+    assert from_bytes.vitals.max_hp.value == 100


### PR DESCRIPTION
Aggregate (de)serialization resolved each dataclass field's annotation with a bare `eval(field.type)`, which evaluated in `bytemaker`'s own namespace. Under PEP 563 (`from __future__ import annotations`) `field.type` is a string such as "SInt16", so the eval raised `NameError` because the concrete `bittype`s were not imported into `aggregate_type`s. Any caller using that future import hit it on the first to/from-bits or to/from-bytes call.

This commit routes all six resolution sites through a shared `resolve_field_types` helper backed by `typing.get_type_hints`, which evaluates string annotations in the defining module's namespace and returns real (non-stringized) annotations unchanged. This makes `from __future__ import annotations` work for aggregate serialization without changing behavior for callers that don't use it.

This commit also adds a `test/future_annotations_test.py` covering (in a module under `from __future__ import annotations` the count, to_bits/from_bits, and to_bytes/from_bytes paths plus a nested dataclass to guard against regressions.

closes #24 