### PR TITLE
fix(bitvector): make replace() non-mutating for equal-length operands

### DIFF
--- a/bytemaker/bitvector/bitvector_with_bitarray_speedup.py
+++ b/bytemaker/bitvector/bitvector_with_bitarray_speedup.py
@@ -1414,6 +1414,10 @@ class BitVector(bitarray, MutableSequence[LaxLiteral01]):
         accumulated_bits: Optional[Self] = None
         if len(old) != len(new):
             accumulated_bits: Optional[Self] = type(self)()
+        else:
+            # The equal-length path patches slices in place,
+            # so work on a copy to keep the receiver unmutated.
+            self = self.copy()
 
         while float(num_replacements) < max_replacements:
             found_index = self.find(old, index)

--- a/test/bittypes_tests/bitarray_test.py
+++ b/test/bittypes_tests/bitarray_test.py
@@ -659,6 +659,8 @@ def test_replace(array, old, new, count, expected):
     bit_array = BitVector(array)
     result = bit_array.replace(BitVector(old), BitVector(new), count)
     assert result.to01() == expected
+    # replace generates a new BitVector; the receiver must be unchanged
+    assert bit_array.to01() == array
 
 
 # join


### PR DESCRIPTION
The bitarray-backed BitVector.replace() patched matches in place on the receiver when len(old) == len(new) and returned self, contradicting its documented "generates a new BitVector" semantics. To address this, instead when working with operands of equal lengths, we use a copy. We also update test_replace such that it asserts the receiver is unchanged after such a call.

Closes #30