### PR TITLE
34 miscellaneous bitvector with speedup fixes (from01 with a character sequence, __setitem__ with str values, replace("", new), Sub-byte BitsCastable results get padded)

### DIFF
--- a/bytemaker/bitvector/bitvector_with_bitarray_speedup.py
+++ b/bytemaker/bitvector/bitvector_with_bitarray_speedup.py
@@ -169,9 +169,12 @@ class BitVector(bitarray, MutableSequence[LaxLiteral01]):
             return self
         # BitsCastable constructor
         elif isinstance(source, BitsCastable):
+            # Copy-construct from the returned BitVector rather than reading
+            # it through the buffer protocol, which would round the length
+            # up to whole bytes.
             curinstance = source.__Bits__()
             self: Self = super().__new__(
-                cls, buffer=curinstance  # type: ignore[reportCallIssue]
+                cls, curinstance  # type: ignore[reportCallIssue]
             )
             return self
 

--- a/bytemaker/bitvector/bitvector_with_bitarray_speedup.py
+++ b/bytemaker/bitvector/bitvector_with_bitarray_speedup.py
@@ -1414,6 +1414,11 @@ class BitVector(bitarray, MutableSequence[LaxLiteral01]):
         assert isinstance(old, type(self))
         assert isinstance(new, type(self))
 
+        if len(old) == 0:
+            # An empty pattern would match at every index without ever
+            # advancing the search, so return an unchanged copy instead.
+            return self.copy()
+
         max_replacements = float("inf") if count is None else count
         num_replacements = 0
 

--- a/bytemaker/bitvector/bitvector_with_bitarray_speedup.py
+++ b/bytemaker/bitvector/bitvector_with_bitarray_speedup.py
@@ -876,14 +876,17 @@ class BitVector(bitarray, MutableSequence[LaxLiteral01]):
            or the bits across the indices given in slice or Sequence form.
 
         An individual bit can be set with a BitsConstructible of length 1.
+
+        A slice or sequence of indices can be set either with a single bit
+           (setting every indexed position to that bit) or with a
+           BitsConstructible (matching positions elementwise; for non-unit
+           slice steps and index sequences, the lengths must agree).
         """
         if isinstance(key, int):
             if not isinstance(value, int):
                 value = BitVector(value)[0]
-        # if isinstance(key, Iterable):
-        #     key = list(key)
-        # elif isinstance(key, slice):
-        #     pass
+        elif not isinstance(value, (int, bitarray)):
+            value = self.cast_if_not_bitvector(value)
         super().__setitem__(key, value)  # type: ignore[reportCallIssue]
 
     def __delitem__(self, key: Union[int, slice, Sequence[int]]) -> None:

--- a/bytemaker/bitvector/bitvector_with_bitarray_speedup.py
+++ b/bytemaker/bitvector/bitvector_with_bitarray_speedup.py
@@ -308,19 +308,23 @@ class BitVector(bitarray, MutableSequence[LaxLiteral01]):
     @classmethod
     def from01(
         cls: type[Self],
-        string: str,
+        string: LaxLiteral01Str,
     ) -> Self:
         """
-        Create a BitVector from a binary string.
+        Create a BitVector from a binary string
+            (or sequence of "0"/"1" characters).
         The string may contain any of '_', '-', ' ', or ':'.
         The string must contain only 0s and 1s other than these.
 
         Args:
-            string (str): The binary string to convert
+            string (Union[Sequence[Literal["0", "1"]], str]): The binary
+                string (or character sequence) to convert
 
         Returns:
             BitVector: The BitVector created from the binary string
         """
+        if not isinstance(string, str):
+            string = "".join(string)
         string = string.translate(str.maketrans("", "", "_- :"))
         bit_array = bitarray(string)
         return cls(bit_array)

--- a/test/bittypes_tests/bitarray_test.py
+++ b/test/bittypes_tests/bitarray_test.py
@@ -129,6 +129,12 @@ def test_from_bin(bin_str, expected_bin):
     # assert bit_array_little_endian.endianness == "little"
 
 
+# from01 with a sequence of characters rather than a string
+def test_from01_char_sequence():
+    assert BitVector.from01(["1", "0", "1"]).to01() == "101"
+    assert BitVector.from01(("1", "0", "1")).to01() == "101"
+
+
 # frombase
 @pytest.mark.parametrize(
     "base_str,base,expected_bin",

--- a/test/bittypes_tests/bitarray_test.py
+++ b/test/bittypes_tests/bitarray_test.py
@@ -52,6 +52,17 @@ def test_invalid_source_type(source, expected_exception):
         BitVector(source)
 
 
+# BitsCastable objects construct from their __Bits__ representation,
+# preserving sub-byte lengths
+class CastableToBits:
+    def __Bits__(self):
+        return BitVector("1100")
+
+
+def test_initialization_from_bitscastable():
+    assert BitVector(CastableToBits()).to01() == "1100"
+
+
 # @pytest.mark.parametrize(
 #     "source,expected_exception",
 #     [

--- a/test/bittypes_tests/bitarray_test.py
+++ b/test/bittypes_tests/bitarray_test.py
@@ -356,6 +356,13 @@ def test_setitem():
     assert a == BitVector("0010")
     a[1:3] = BitVector("11")
     assert a == BitVector("0110")
+    # BitsConstructible values are converted
+    a[1:3] = "00"
+    assert a == BitVector("0000")
+    a[1:4] = "111111"  # unit-step slices resize to fit the value
+    assert a == BitVector("0111111")
+    a[[0, 1]] = "10"
+    assert a == BitVector("1011111")
 
 
 # __delitem__

--- a/test/bittypes_tests/bitarray_test.py
+++ b/test/bittypes_tests/bitarray_test.py
@@ -676,6 +676,14 @@ def test_replace(array, old, new, count, expected):
     assert bit_array.to01() == array
 
 
+# replace with an empty pattern terminates and leaves the bits unchanged
+def test_replace_empty_old_returns_copy():
+    bit_array = BitVector("1010")
+    result = bit_array.replace(BitVector(""), BitVector("1"))
+    assert result == bit_array
+    assert result is not bit_array
+
+
 # join
 @pytest.mark.parametrize(
     "separator,iterable,expected",


### PR DESCRIPTION
closes #34 